### PR TITLE
add Variable for ouput video frame rate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ ENV \
     TEMPLATE="border" \
     VIDEO_RESOLUTION="1080p" \
     XVFB_WHD="3840x2160x24" \
-    GOURCE_FPS = "60"
+    GOURCE_FPS="60"
 
 # Expose port 80 to serve mp4 video over HTTP
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,8 @@ ENV \
     OVERLAY_FONT_COLOR="0f5ca8" \
     TEMPLATE="border" \
     VIDEO_RESOLUTION="1080p" \
-    XVFB_WHD="3840x2160x24"
+    XVFB_WHD="3840x2160x24" \
+    GOURCE_FPS = "60"
 
 # Expose port 80 to serve mp4 video over HTTP
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Now open your browser to <http://localhost:8080/> and once the video is complete
 | `H264_CRF`                 | `23`                             | The Constant Rate Factor (CRF) is the default quality for h.264 encoding. refer to [FFmpeg's wiki][ffmpeg]. |
 | `H264_LEVEL`               | `5.1`                            | h.264 encoding level. Refer to [FFmpeg's wiki][ffmpeg].                                                     |
 | `VIDEO_RESOLUTION`         | `1080p`                          | Output video resolution, options are **2160p, 1440p, 1080p, 720p**                                          |
+| `GOURCE_FPS`         | `60`                          | Output video frame rate                                          |
 | `TEMPLATE`                 | `border`                         | This is the template script that will be run. Options are **border**, and **none**.                         |
 | `GOURCE_TITLE`             | `Software Development`           | Title to be displayed in the lower left hand corner of video.                                               |
 | `OVERLAY_FONT_COLOR`       | `0f5ca8`                         | Font color to be used on the overlay (Date only).                                                           |

--- a/border_template.sh
+++ b/border_template.sh
@@ -10,7 +10,7 @@ if [[ "${VIDEO_RESOLUTION}" == "2160p" ]]; then
 	DATE_CROP="3520:200:640:0"
 	DATE_PAD="3840:200:320:200:#202021"
 	OUTPUT_RES="3840:2160"
-	echo "Using 2160p settings. Output will be 3840x2160 at 60fps."
+	echo "Using 2160p settings. Output will be 3840x2160 at ${GOURCE_FPS}fps."
 elif [[ "${VIDEO_RESOLUTION}" == "1440p" ]]; then
 	GOURCE_RES="2333x1293"
 	OVERLAY_RES="1920x1080"
@@ -20,7 +20,7 @@ elif [[ "${VIDEO_RESOLUTION}" == "1440p" ]]; then
 	DATE_CROP="2346:134:426:0"
 	DATE_PAD="2560:134:214:134:#202021"
 	OUTPUT_RES="2560:1440"
-	echo "Using 1440p settings. Output will be 2560x1440 at 60fps."
+	echo "Using 1440p settings. Output will be 2560x1440 at ${GOURCE_FPS}fps."
 elif [[ "${VIDEO_RESOLUTION}" == "1080p" ]]; then
 	GOURCE_RES="1750x970"
 	OVERLAY_RES="1920x1080"
@@ -30,7 +30,7 @@ elif [[ "${VIDEO_RESOLUTION}" == "1080p" ]]; then
 	DATE_CROP="1760:100:320:0"
 	DATE_PAD="1920:100:160:100:#202021"
 	OUTPUT_RES="1920:1080"
-	echo "Using 1080p settings. Output will be 1920x1080 at 60fps."
+	echo "Using 1080p settings. Output will be 1920x1080 at ${GOURCE_FPS}fps."
 elif [[ "${VIDEO_RESOLUTION}" == "720p" ]]; then
 	GOURCE_RES="1116x646"
 	OVERLAY_RES="1920x1080"
@@ -40,7 +40,7 @@ elif [[ "${VIDEO_RESOLUTION}" == "720p" ]]; then
 	DATE_CROP="1128:67:152:0"
 	DATE_PAD="1280:67:152:0:#202021"
 	OUTPUT_RES="1280:720"
-	echo "Using 720p settings. Output will be 1280x720 at 60fps."
+	echo "Using 720p settings. Output will be 1280x720 at ${GOURCE_FPS}fps."
 fi
 
 if [[ "${INVERT_COLORS}" == "true" ]]; then
@@ -74,7 +74,7 @@ gource --seconds-per-day ${GOURCE_SECONDS_PER_DAY} \
 	--${GOURCE_RES} \
 	--stop-at-end \
 	./development.log \
-	-r 60 \
+	-r ${GOURCE_FPS} \
 	-o - >./tmp/gource.pipe &
 
 # Start Gource for the overlay elements.
@@ -96,14 +96,14 @@ gource --seconds-per-day ${GOURCE_SECONDS_PER_DAY} \
 	--filename-time 2 \
 	--max-user-speed 500 \
 	./development.log \
-	-r 60 \
+	-r ${GOURCE_FPS} \
 	-o - >./tmp/overlay.pipe &
 
 # Start ffmpeg to merge the two video outputs.
 echo "Combining videos."
 mkdir -p ./video
-ffmpeg -y -r 60 -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
-	-y -r 60 -f image2pipe -probesize 100M -i ./tmp/overlay.pipe \
+ffmpeg -y -r ${GOURCE_FPS} -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
+	-y -r ${GOURCE_FPS} -f image2pipe -probesize 100M -i ./tmp/overlay.pipe \
 	${LOGO} \
 	-filter_complex "[0:v]pad=${GOURCE_PAD}${GOURCE_FILTERS}[center];\
                          [1:v]scale=${OUTPUT_RES}[key_scale];\

--- a/no_template.sh
+++ b/no_template.sh
@@ -3,16 +3,16 @@
 # Predefined resolutions and settings.
 if [[ "${VIDEO_RESOLUTION}" == "2160p" ]]; then
 	GOURCE_RES="3840x2160"
-	echo "Using 2160p settings. Output will be 3840x2160 at 60fps."
+	echo "Using 2160p settings. Output will be 3840x2160 at ${GOURCE_FPS}fps."
 elif [[ "${VIDEO_RESOLUTION}" == "1440p" ]]; then
 	GOURCE_RES="2560x1440"
-	echo "Using 1440p settings. Output will be 2560x1440 at 60fps."
+	echo "Using 1440p settings. Output will be 2560x1440 at ${GOURCE_FPS}fps."
 elif [[ "${VIDEO_RESOLUTION}" == "1080p" ]]; then
 	GOURCE_RES="1920x1080"
-	echo "Using 1080p settings. Output will be 1920x1080 at 60fps."
+	echo "Using 1080p settings. Output will be 1920x1080 at ${GOURCE_FPS}fps."
 elif [[ "${VIDEO_RESOLUTION}" == "720p" ]]; then
 	GOURCE_RES="1280x720"
-	echo "Using 720p settings. Output will be 1280x720 at 60fps."
+	echo "Using 720p settings. Output will be 1280x720 at ${GOURCE_FPS}fps."
 fi
 
 if [[ "${INVERT_COLORS}" == "true" ]]; then
@@ -49,29 +49,29 @@ gource --seconds-per-day ${GOURCE_SECONDS_PER_DAY} \
 	--${GOURCE_RES} \
 	--stop-at-end \
 	./development.log \
-	-r 60 \
+	-r ${GOURCE_FPS} \
 	-o - >./tmp/gource.pipe &
 
 # Start ffmpeg to merge the two video outputs.
 mkdir -p ./video
 if [[ "${LOGO_FILTER_GRAPH}" != "" ]]; then
 	if [[ "${GOURCE_FILTERS}" != "" ]]; then
-		ffmpeg -y -r 60 -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
+		ffmpeg -y -r ${GOURCE_FPS} -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
 			${LOGO} \
 			-filter_complex "[0:v]${GOURCE_FILTERS}[filtered];[filtered]${LOGO_FILTER_GRAPH}${GLOBAL_FILTERS}" ${FILTER_GRAPH_MAP} \
 			-vcodec libx264 -level ${H264_LEVEL} -pix_fmt yuv420p -crf ${H264_CRF} -preset ${H264_PRESET} -bf 0 ./video/output.mp4
 	else
-		ffmpeg -y -r 60 -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
+		ffmpeg -y -r ${GOURCE_FPS} -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
 			${LOGO} \
 			-filter_complex "[0:v]${LOGO_FILTER_GRAPH}${GLOBAL_FILTERS}" ${FILTER_GRAPH_MAP} \
 			-vcodec libx264 -level ${H264_LEVEL} -pix_fmt yuv420p -crf ${H264_CRF} -preset ${H264_PRESET} -bf 0 ./video/output.mp4
 	fi
 elif [[ "${GOURCE_FILTERS}" != "" ]]; then
-	ffmpeg -y -r 60 -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
+	ffmpeg -y -r ${GOURCE_FPS} -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
 		-filter_complex "${GOURCE_FILTERS}${GLOBAL_FILTERS}" ${FILTER_GRAPH_MAP} \
 		-vcodec libx264 -level ${H264_LEVEL} -pix_fmt yuv420p -crf ${H264_CRF} -preset ${H264_PRESET} -bf 0 ./video/output.mp4
 else
-	ffmpeg -y -r 60 -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
+	ffmpeg -y -r ${GOURCE_FPS} -f image2pipe -probesize 100M -i ./tmp/gource.pipe \
 		-vcodec libx264 -level ${H264_LEVEL} -pix_fmt yuv420p -crf ${H264_CRF} -preset ${H264_PRESET} -bf 0 ./video/output.mp4
 fi
 


### PR DESCRIPTION
-e GOURCE_FPS=30 now sets the output video frame rate to 30 frames per second. In my use case, the video is being displayed on screens only capable of 30hz so anything above this would just be dropped. there is barely any visual difference by dropping the frame rate to 30 but the files are smaller and the render time is reduced. I think it's a nice option to have. The default is still set at 60fps if the option is not used.